### PR TITLE
upgraded openai to handle exponential backoff

### DIFF
--- a/backend/main/package.json
+++ b/backend/main/package.json
@@ -13,7 +13,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.0.3",
     "express": "^4.18.2",
-    "openai": "^3.2.1",
+    "openai": "^4.17.5",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.0.4"
   },


### PR DESCRIPTION
Currently, there's an issue #8 that causes components not to get generated. This is because OpenAI caps how many tokens/minute you can make.

I've updated the OpenAI library to version 4, and this includes retries + exponential backoff. I made the retry limit = 100, which gives the client more than enough retries to generate all components. 